### PR TITLE
rename function parameters to be consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,3 @@ fabric.properties
 # Azure Toolkit for IntelliJ plugin
 # https://plugins.jetbrains.com/plugin/8053-azure-toolkit-for-intellij
 .idea/**/azureSettings.xml
-
-
-third_party_c

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ SUCCESS=$(BOLD)$(GREEN)
 INFO=$(BOLD)$(CYAN)
 
 CC := gcc
-CFLAGS := -std=c99 -Wall -Wextra -Wvla -O1 -g3 -pedantic -v -fsanitize=address,undefined -fno-omit-frame-pointer -fno-optimize-sibling-calls -fno-common
+CFLAGS := -std=c11 -Wall -Wextra -Wvla -O1 -g3 -pedantic -v -fsanitize=address,undefined -fno-omit-frame-pointer -fno-optimize-sibling-calls -fno-common
 DBG = gdb
 LDFLAGS := -v -lc #-lpthread -lm
 

--- a/common.h
+++ b/common.h
@@ -57,9 +57,6 @@ extern "C" {
 #include <netdb.h>      // Network operations (gethostbyname(), getaddrinfo())
 #include <sys/socket.h> // Socket programming (socket(), bind(), listen())
 
-// #include "third_party_c/internal_debug.h" // internal mem debug and print
-// debug
-
 //------------------------------------------------------------------------------
 // Utility Macros
 //------------------------------------------------------------------------------

--- a/main.c
+++ b/main.c
@@ -11,7 +11,6 @@
  *
  */
 
-// #include "third_party_c/internal_debug.h"
 #include "watchdog.h"
 
 int main(int argc, char **argv) {
@@ -19,19 +18,17 @@ int main(int argc, char **argv) {
     (void)argv;
     w_create();
     int *a = w_malloc(10 * sizeof(*a), __FILE__, __LINE__, __func__);
-    a = w_malloc(20 * sizeof(*a), __FILE__, __LINE__, __func__);
     int *b = w_malloc(1024 * sizeof(*a), __FILE__, __LINE__, __func__);
     int *c = w_malloc(1024 * sizeof(*a), __FILE__, __LINE__, __func__);
     int *d = w_malloc(1024 * sizeof(*a), __FILE__, __LINE__, __func__);
     int *e = w_malloc(1024 * sizeof(*a), __FILE__, __LINE__, __func__);
     int *f = w_malloc(1024 * sizeof(*a), __FILE__, __LINE__, __func__);
-    w_free(a, __FILE__, __LINE__, __func__);
-    w_free(b, __FILE__, __LINE__, __func__);
-    w_free(c, __FILE__, __LINE__, __func__);
-    w_free(d, __FILE__, __LINE__, __func__);
-    w_free(e, __FILE__, __LINE__, __func__);
-    w_free(f, __FILE__, __LINE__, __func__);
+    // w_free(a, __FILE__, __LINE__, __func__);
+    // w_free(b, __FILE__, __LINE__, __func__);
+    // w_free(c, __FILE__, __LINE__, __func__);
+    // w_free(d, __FILE__, __LINE__, __func__);
+    // w_free(e, __FILE__, __LINE__, __func__);
+    // w_free(f, __FILE__, __LINE__, __func__);
 
-    // forge_run();
     return 0;
 }

--- a/watchdog.h
+++ b/watchdog.h
@@ -17,39 +17,13 @@ extern "C" {
 #endif // __cplusplus
 
 #include "common.h"
-
-struct w_alloc_node {
-    void *pointer;
-    size_t size;
-    char *file;
-    unsigned int line;
-    char *function;
-    bool freed;
-    struct w_alloc_node *next;
-};
-
-struct w_freed_node {
-    struct w_alloc_node *alloc;
-    char *file;
-    unsigned int line;
-    char *function;
-    struct w_freed_node *next;
-};
-
-struct watchdog {
-    struct w_alloc_node *alloc_head;
-    struct w_freed_node *freed_head;
-    size_t total_bytes_alloc;
-    size_t total_bytes_freed;
-    size_t total_allocations;
-    size_t total_frees;
-};
+#include "watchdog.h"
 
 #ifdef WATCHDOG_ENABLE
-#define malloc(size) w_malloc(size, file, line, function)
-#define realloc(pointer, size) w_realloc(pointer, size, file, line, function)
-#define calloc(count, size) w_calloc(count, size, file, line, function)
-#define free(pointer) w_free(pointer, file, line, function)
+#define malloc(size) w_malloc(size, __FILE__, __LINE__, __func__)
+#define realloc(ptr, size) w_realloc(ptr, size, __FILE__, __LINE__, __func__)
+#define calloc(count, size) w_calloc(count, size, __FILE__, __LINE__, __func__)
+#define free(ptr) w_free(ptr, __FILE__, __LINE__, __func__)
 #else
 #undef malloc
 #undef realloc
@@ -59,13 +33,13 @@ struct watchdog {
 
 extern void w_create(void);
 extern void *w_malloc(size_t size, const char *file, unsigned int line,
-                      const char *function);
-extern void *w_realloc(void *pointer, size_t size, const char *file,
-                       unsigned int line, const char *function);
+                      const char *func);
+extern void *w_realloc(void *ptr, size_t size, const char *file,
+                       unsigned int line, const char *func);
 extern void *w_calloc(size_t count, size_t size, const char *file,
-                      unsigned int line, const char *function);
-extern void w_free(void *pointer, const char *file, unsigned int line,
-                   const char *function);
+                      unsigned int line, const char *func);
+extern void w_free(void *ptr, const char *file, unsigned int line,
+                   const char *func);
 extern void w_report(void);
 extern void w_dump(void);
 extern void w_destroy(void);


### PR DESCRIPTION
- remove third party libraries
- change c99 to c11
- rename function parameters to be more consistent with language standards