### PR TITLE
refactor(scope)!: make error checking more verbose

### DIFF
--- a/watchdog.c
+++ b/watchdog.c
@@ -18,57 +18,48 @@ struct w_alloc_node {
     char *file;
     unsigned int line;
     char *func;
+    bool mallocd;
+    bool reallocd;
+    bool callocd;
     bool freed;
     struct w_alloc_node *next;
 };
 
-struct w_freed_node {
-    struct w_alloc_node *alloc;
-    char *file;
-    unsigned int line;
-    char *func;
-    struct w_freed_node *next;
-};
-
 struct watchdog {
     struct w_alloc_node *alloc_head;
-    struct w_freed_node *freed_head;
     size_t total_allocations;
     size_t total_bytes_alloc;
     size_t total_frees;
     size_t total_bytes_freed;
-    bool watchdog_initialized;
 };
 
-static struct watchdog watchdog;
+static void w_alloc_check_internal(void *ptr, const size_t size,
+                                   const char *file, const unsigned int line,
+                                   const char *func) {
+    if (!ptr) {
+        fprintf(stderr,
+                "[%s:%u:(%s)] Memory allocation error. Failed to allocate %lu "
+                "bytes to memory address %p.\n",
+                file, line, func, size, (void *)ptr);
+        exit(EXIT_FAILURE);
+    }
+}
+
+static struct watchdog *watchdog = NULL;
 
 void w_create(void) {
-    watchdog.alloc_head = NULL;
-    watchdog.freed_head = NULL;
-    watchdog.total_bytes_alloc = 0;
-    watchdog.total_bytes_freed = 0;
-    watchdog.total_allocations = 0;
-    watchdog.total_frees = 0;
-    watchdog.watchdog_initialized = true;
-}
-
-static void w_initialized_check_internal(const char *file,
-                                         const unsigned int line,
-                                         const char *func) {
-    if (!watchdog.watchdog_initialized) {
-        fprintf(stderr, "[%s:%u:(%s)] w_create() must be called first.\n", file,
-                line, func);
-        exit(EXIT_FAILURE);
+    if (!watchdog) {
+        watchdog = malloc(sizeof *watchdog);
+        w_alloc_check_internal(watchdog, sizeof *watchdog, __FILE__, __LINE__,
+                               __func__);
+    } else {
+        return;
     }
-}
-
-static void w_alloc_check_internal(void *ptr, const char *file,
-                                   const unsigned int line, const char *func) {
-    if (!ptr) {
-        fprintf(stderr, "[%s:%u:(%s)] Memory allocation error.\n", file, line,
-                func);
-        exit(EXIT_FAILURE);
-    }
+    watchdog->alloc_head = NULL;
+    watchdog->total_bytes_alloc = 0;
+    watchdog->total_bytes_freed = 0;
+    watchdog->total_allocations = 0;
+    watchdog->total_frees = 0;
 }
 
 static struct w_alloc_node *
@@ -76,22 +67,24 @@ w_alloc_node_create_internal(const size_t size, const char *file,
                              const unsigned int line, const char *func) {
     struct w_alloc_node *node;
     node = malloc(sizeof(*node));
-    w_alloc_check_internal(node, __FILE__, __LINE__, __func__);
+    w_alloc_check_internal(node, sizeof(*node), __FILE__, __LINE__, __func__);
     node->next = NULL;
 
     node->size = size;
     node->ptr = malloc(node->size);
-    w_alloc_check_internal(node->ptr, __FILE__, __LINE__, __func__);
+    w_alloc_check_internal(node->ptr, node->size, __FILE__, __LINE__, __func__);
 
     node->file = malloc((strlen(file) + 1) * sizeof(*node->file));
-    w_alloc_check_internal(node->file, __FILE__, __LINE__, __func__);
+    w_alloc_check_internal(node->file, (strlen(file) + 1) * sizeof(*node->file),
+                           __FILE__, __LINE__, __func__);
     memcpy(node->file, file, strlen(file));
     node->file[strlen(file)] = '\0';
 
     node->line = line;
 
     node->func = malloc((strlen(func) + 1) * sizeof(*node->func));
-    w_alloc_check_internal(node->func, __FILE__, __LINE__, __func__);
+    w_alloc_check_internal(node->func, (strlen(func) + 1) * sizeof(*node->func),
+                           __FILE__, __LINE__, __func__);
     memcpy(node->func, func, strlen(func));
     node->func[strlen(func)] = '\0';
 
@@ -115,119 +108,36 @@ static void w_alloc_node_destroy_internal(struct w_alloc_node *node) {
 
 void *w_malloc(const size_t size, const char *file, const unsigned int line,
                const char *func) {
-
+    w_create();
     struct w_alloc_node *node;
     node = w_alloc_node_create_internal(size, file, line, func);
-    watchdog.total_allocations++;
-    watchdog.total_bytes_alloc += size;
+    watchdog->total_allocations++;
+    watchdog->total_bytes_alloc += size;
 
-    if (!watchdog.alloc_head) {
-        watchdog.alloc_head = node;
+    if (!watchdog->alloc_head) {
+        watchdog->alloc_head = node;
     } else {
-        node->next = watchdog.alloc_head;
-        watchdog.alloc_head = node;
+        node->next = watchdog->alloc_head;
+        watchdog->alloc_head = node;
     }
 
     return node->ptr;
 }
 
-static struct w_freed_node *
-w_freed_node_create_internal(const char *file, const unsigned int line,
-                             const char *func) {
-
-    struct w_freed_node *node;
-    node = malloc(sizeof(*node));
-    w_alloc_check_internal(node, __FILE__, __LINE__, __func__);
-    node->next = NULL;
-
-    node->file = malloc((strlen(file) + 1) * sizeof(*node->file));
-    w_alloc_check_internal(node->file, __FILE__, __LINE__, __func__);
-    memcpy(node->file, file, strlen(file));
-    node->file[strlen(file)] = '\0';
-
-    node->line = line;
-
-    node->func = malloc((strlen(func) + 1) * sizeof(*node->func));
-    w_alloc_check_internal(node->func, __FILE__, __LINE__, __func__);
-    memcpy(node->func, func, strlen(func));
-    node->func[strlen(func)] = '\0';
-
-    return node;
-}
-
-static void w_freed_node_destroy_internal(struct w_freed_node *node) {
-    free(node->func);
-    node->func = NULL;
-    free(node->file);
-    node->file = NULL;
-    free(node);
-    node = NULL;
-}
-
-void w_free(void *ptr, const char *file, const unsigned int line,
-            const char *func) {
-
-    if (!watchdog.freed_head) {
-
-        struct w_freed_node *node;
-        node = w_freed_node_create_internal(file, line, func);
-
-        struct w_alloc_node *temp;
-        temp = watchdog.alloc_head;
-        // TODO: this should be a separate helper function
-        while (temp) {
-            if (temp->ptr == ptr) {
-                node->alloc = temp;
-                free(node->alloc->ptr);
-            }
-            temp = temp->next;
-        }
-        watchdog.freed_head = node;
-    } else {
-        struct w_freed_node *temp;
-        struct w_freed_node *tail;
-        temp = watchdog.freed_head;
-        // FIX: double check and test this logic, might be broken
-        // TODO: separate helper function to check for double free
-        while (temp) {
-            if (temp->alloc->ptr == ptr) {
-                fprintf(stderr, "Error: Double free.\n");
-                exit(EXIT_FAILURE);
-            }
-            if (!temp->next) {
-                tail = temp;
-            }
-            temp = temp->next;
-        }
-
-        struct w_freed_node *node;
-        node = w_freed_node_create_internal(file, line, func);
-
-        struct w_alloc_node *temp2;
-        temp2 = watchdog.alloc_head;
-        while (temp2) {
-            if (temp2->ptr == ptr) {
-                node->alloc = temp2;
-                free(node->alloc->ptr);
-            }
-            temp2 = temp2->next;
-        }
-        tail->next = node;
-    }
-}
-
 void *w_realloc(void *ptr, size_t size, const char *file, unsigned int line,
                 const char *func) {
+
+    w_create();
     struct w_alloc_node *node;
     node = w_alloc_node_create_internal(size, file, line, func);
-    watchdog.total_allocations++;
-    watchdog.total_bytes_alloc += size;
+    watchdog->total_allocations++;
+    watchdog->total_bytes_alloc += size;
 
-    if (!watchdog.alloc_head) {
-        watchdog.alloc_head = node;
+    if (!watchdog->alloc_head) {
+        watchdog->alloc_head = node;
     } else {
-        node->next = watchdog.alloc_head;
-        watchdog.alloc_head = node;
+        node->next = watchdog->alloc_head;
+        watchdog->alloc_head = node;
     }
 
     return node->ptr;
@@ -235,28 +145,36 @@ void *w_realloc(void *ptr, size_t size, const char *file, unsigned int line,
 
 void *w_calloc(size_t count, size_t size, const char *file, unsigned int line,
                const char *func) {
+
+    w_create();
     struct w_alloc_node *node;
     node = w_alloc_node_create_internal(size, file, line, func);
-    watchdog.total_allocations++;
-    watchdog.total_bytes_alloc += size;
+    watchdog->total_allocations++;
+    watchdog->total_bytes_alloc += size;
 
-    if (!watchdog.alloc_head) {
-        watchdog.alloc_head = node;
+    if (!watchdog->alloc_head) {
+        watchdog->alloc_head = node;
     } else {
-        node->next = watchdog.alloc_head;
-        watchdog.alloc_head = node;
+        node->next = watchdog->alloc_head;
+        watchdog->alloc_head = node;
     }
 
     return node->ptr;
 }
 
+void w_free(void *ptr, const char *file, const unsigned int line,
+            const char *func) {
+    w_create();
+}
+
 // FIX: consistent formatting of output
 void w_report(void) {
+    w_create();
     printf("Watchdog Report\n");
-    printf("Allocations: %zu\n", watchdog.total_allocations);
-    printf("Allocated Bytes: %zu\n", watchdog.total_bytes_alloc);
-    printf("Frees: %zu\n", watchdog.total_frees);
-    printf("Freed Bytes: %zu\n", watchdog.total_bytes_freed);
+    printf("Allocations: %zu\n", watchdog->total_allocations);
+    printf("Allocated Bytes: %zu\n", watchdog->total_bytes_alloc);
+    printf("Frees: %zu\n", watchdog->total_frees);
+    printf("Freed Bytes: %zu\n", watchdog->total_bytes_freed);
 }
 void w_dump(void) {}
 void w_destroy(void) {}


### PR DESCRIPTION
- allocation errors now show the size that was meant to be allocated
- remove freed_node struct
- add bools to alloc node for realloc, malloc, and calloc

BREAKING CHANGE: API no longer requires calling w_create() and w_destroy()