### PR TITLE
prevents issues with dangling pointers if the original strings are freed or go out of scope.

### DIFF
--- a/src/watchdog.c
+++ b/src/watchdog.c
@@ -381,6 +381,11 @@ static void WAM_alloc_create_internal(void *ptr, const size_t size,
     WAM *data = malloc(sizeof *data);
     w_alloc_check_internal(data, sizeof *data, __FILE__, __LINE__, __func__);
 
+#if WATCHDOG_COPY_STRINGS
+    file = file ? strdup(file) : NULL;
+    func = func ? strdup(func) : NULL;
+#endif
+
     data->ptr   = ptr;
     data->size  = size;
     data->file  = file;
@@ -465,7 +470,13 @@ static void WDA_pop(void) {
         return;
     }
     watchdog.size--;
-    free(watchdog.buffer[watchdog.size]);
+    if (watchdog.buffer[watchdog.size]) {
+#if WATCHDOG_COPY_STRINGS
+        free(watchdog.buffer[watchdog.size]->file);
+        free(watchdog.buffer[watchdog.size]->func);
+#endif
+        free(watchdog.buffer[watchdog.size]);
+    }
     watchdog.buffer[watchdog.size] = NULL;
 }
 

--- a/src/watchdog.h
+++ b/src/watchdog.h
@@ -15,6 +15,14 @@
 extern "C" {
 #endif // __cplusplus
 
+// Option which clones all strings (file and func names) to prevent broken references
+// (useful in case when dynamic libraries are involved). This may have performance and memory usage impact.
+// Another option is to keep all loaded libraries till the program ends (see RTLD_NODELETE
+// and GET_MODULE_HANDLE_EX_FLAG_PIN (nb: FreeLibrary does not work with GET_MODULE_HANDLE_EX_FLAG_PIN flag)).
+#ifndef WATCHDOG_COPY_STRINGS
+#define WATCHDOG_COPY_STRINGS 0
+#endif // WATCHDOG_COPY_STRINGS
+
 //------------------------------------------------------------------------------
 // Includes
 //------------------------------------------------------------------------------


### PR DESCRIPTION
For example, if a function was from a dynamically loaded library and that library is unloaded